### PR TITLE
Search by location and date range in earthquake list

### DIFF
--- a/src/components/EarthquakeList.vue
+++ b/src/components/EarthquakeList.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 
 //Components
 import Card from 'primevue/card';
@@ -117,8 +117,12 @@ const filteredEarthquakes = computed<Earthquake[]>(() => {
         :minDate="minimumDate"
         :maxDate="maximumDate"
         :manualInput="false"
+        placeholder="Select a date range"
         selectionMode="range"
-        showButtonBar />
+        iconDisplay="input"
+        showIcon
+        showButtonBar>
+      </DatePicker>
 
       <span class="text-sm">Showing {{ filteredEarthquakes.length }} earthquakes</span>
 

--- a/src/components/EarthquakeList.vue
+++ b/src/components/EarthquakeList.vue
@@ -117,6 +117,7 @@ const filteredEarthquakes = computed<Earthquake[]>(() => {
         :minDate="minimumDate"
         :maxDate="maximumDate"
         :manualInput="false"
+        class="mb-2"
         placeholder="Select a date range"
         selectionMode="range"
         iconDisplay="input"
@@ -124,7 +125,9 @@ const filteredEarthquakes = computed<Earthquake[]>(() => {
         showButtonBar>
       </DatePicker>
 
-      <span class="text-sm">Showing {{ filteredEarthquakes.length }} earthquakes</span>
+      <span class="text-sm text-surface-500 dark:text-surface-400 mx-auto"
+        >Showing {{ filteredEarthquakes.length }} earthquakes</span
+      >
 
       <div class="grow">
         <!-- Virtually scrolls to handle lots of results -->

--- a/src/components/EarthquakeList.vue
+++ b/src/components/EarthquakeList.vue
@@ -1,17 +1,40 @@
 <script lang="ts" setup>
-import { ref, computed } from 'vue';
+import { computed, ref } from 'vue';
+
+//Components
 import Card from 'primevue/card';
-import { useSourceDataStore } from '@/stores/sourceDataStore';
-import type { Earthquake } from '@/consts/earthquake.types';
+import DatePicker from 'primevue/datepicker';
+import InputText from 'primevue/inputtext';
 import Listbox from 'primevue/listbox';
+
+//Types
+import type { Earthquake } from '@/consts/earthquake.types';
 import type { FeatureCollection } from 'geojson';
 import type { Feature } from 'geojson';
+
+//Store
+import { useSourceDataStore } from '@/stores/sourceDataStore';
+import { useEarthquakeStateStore } from '@/stores/earthquakeStateStore';
+import { storeToRefs } from 'pinia';
+
+//Helpers
 import { formatDate } from '@/helpers/formatDate.ts';
 import { getMagnitudeIcon } from '@/helpers/getMagnitudeIcon.ts';
 
 const sourceDataStore = useSourceDataStore();
+const earthquakeStateStore = useEarthquakeStateStore();
 
-const selectedEarthquake = ref<Earthquake | null>(null);
+const { selectedEarthquake, filterSearchTerm, filterDates } = storeToRefs(earthquakeStateStore);
+
+const minimumDate = computed<Date>(() => {
+  //Return date 30 days ago
+  return new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+});
+
+const maximumDate = computed<Date>(() => {
+  //Return today's date
+  return new Date();
+});
 
 const data = computed<FeatureCollection>(() => {
   return (
@@ -37,14 +60,45 @@ const earthquakes = computed<Earthquake[]>(() => {
     };
   });
 
+  //TODO: Remove
   console.log(mappedData);
 
   return mappedData;
 });
+
+const filteredEarthquakes = computed<Earthquake[]>(() => {
+  return earthquakes.value.filter((earthquake: Earthquake) => {
+    // If search term exists, check if place includes it
+    if (
+      filterSearchTerm.value &&
+      !earthquake.place.toLowerCase().includes(filterSearchTerm.value.toLowerCase())
+    ) {
+      return false;
+    }
+
+    // Date filtering
+    if (earthquakeStateStore.filterDates?.length === 2) {
+      const earthquakeDate = new Date(earthquake.time);
+
+      const startDate = new Date(earthquakeStateStore.filterDateFromTimestamp);
+      startDate.setHours(0, 0, 0, 0);
+
+      const endDate = new Date(earthquakeStateStore.filterDateToTimestamp);
+      endDate.setHours(23, 59, 59, 999);
+
+      if (earthquakeDate < startDate || earthquakeDate > endDate) {
+        return false;
+      }
+    }
+
+    // If we didn't return false above, this earthquake passes all filters
+    return true;
+  });
+});
 </script>
 <template>
   <Card
-    class="!w-70"
+    class="!w-80"
     :pt="{
       body: {
         class: '!p-3 h-full',
@@ -57,13 +111,22 @@ const earthquakes = computed<Earthquake[]>(() => {
     <template #subtitle>Seismic earthquake data provided by USGS.gov</template>
 
     <template #content>
-      <span class="text-sm">Showing {{ earthquakes.length }} earthquakes</span>
+      <InputText v-model="filterSearchTerm" placeholder="Search for a location" class="mb-2" />
+      <DatePicker
+        v-model="filterDates"
+        :minDate="minimumDate"
+        :maxDate="maximumDate"
+        :manualInput="false"
+        selectionMode="range"
+        showButtonBar />
+
+      <span class="text-sm">Showing {{ filteredEarthquakes.length }} earthquakes</span>
 
       <div class="grow">
         <!-- Virtually scrolls to handle lots of results -->
         <Listbox
           v-model="selectedEarthquake"
-          :options="earthquakes"
+          :options="filteredEarthquakes"
           optionLabel="place"
           optionValue="id"
           :virtualScrollerOptions="{ itemSize: 55 }"

--- a/src/pages/MapPage.vue
+++ b/src/pages/MapPage.vue
@@ -18,9 +18,9 @@ onMounted(async () => {
   mapStore.map?.on('load', async () => {
     await loadData(
       //All over 1 mag, the last week
-      'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/1.0_week.geojson',
+      //'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/1.0_week.geojson',
       //All the last month
-      //'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_month.geojson',
+      'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_month.geojson',
       'earthquakes',
     );
 

--- a/src/stores/earthquakeStateStore.ts
+++ b/src/stores/earthquakeStateStore.ts
@@ -1,0 +1,29 @@
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+import type { Earthquake } from '@/consts/earthquake.types';
+
+export const useEarthquakeStateStore = defineStore('earthquakeState', () => {
+  const selectedEarthquake = ref<Earthquake | null>();
+  const filterSearchTerm = ref<string>('');
+  const filterDates = ref<Date[]>([]);
+
+  const filterDateFromTimestamp = computed<number>(() => {
+    return filterDates.value[0]?.getTime();
+  });
+
+  const filterDateToTimestamp = computed<number>(() => {
+    return filterDates.value[1]?.getTime();
+  });
+
+  //TODO: Timestamps
+  //   const filterFromTimestamp = ref<string>('');
+  //   const filterToTimestamp = ref<string>('');
+
+  return {
+    selectedEarthquake,
+    filterSearchTerm,
+    filterDates,
+    filterDateFromTimestamp,
+    filterDateToTimestamp,
+  };
+});


### PR DESCRIPTION
- Switched source to show results for past 30 days instead of 7, since it's now a virtual scrolling list.
- earthquake state pinia store for holding the selected earthquake, as well as any applied filters
- searchable list by place name
- filterable list by date range
- tidier dark mode classes

![image](https://github.com/user-attachments/assets/2cea60c4-bfa4-477c-8f47-8cdcb6c04c71)
