### PR TITLE
Filters now also refine map results (layer-level filtering and source-level filtering)

### DIFF
--- a/src/consts/layers.ts
+++ b/src/consts/layers.ts
@@ -1,7 +1,9 @@
+import type { Layer, ExpressionSpecification, PaintSpecification } from 'mapbox-gl';
+
 interface LayerConsts {
-  [key: string]: mapboxgl.Layer;
+  [key: string]: Layer;
 }
-const magnitudeColorExpression: mapboxgl.ExpressionSpecification = [
+const magnitudeColorExpression: ExpressionSpecification = [
   'case',
   ['<', ['get', 'mag'], 3],
   '#008236', // Green for mag < 3
@@ -12,7 +14,7 @@ const magnitudeColorExpression: mapboxgl.ExpressionSpecification = [
   '#FFFFFF', // Default color (optional, in case mag is missing)
 ];
 
-const interpolatedMagnitudeColorExpression: mapboxgl.ExpressionSpecification = [
+const interpolatedMagnitudeColorExpression: ExpressionSpecification = [
   'interpolate',
   ['linear'],
   ['get', 'mag'],
@@ -30,7 +32,7 @@ const interpolatedMagnitudeColorExpression: mapboxgl.ExpressionSpecification = [
   '#f00',
 ];
 
-const interpolatedMagnitudeHeightExpression: mapboxgl.ExpressionSpecification = [
+const interpolatedMagnitudeHeightExpression: ExpressionSpecification = [
   'interpolate',
   ['linear'],
   ['get', 'mag'],
@@ -48,7 +50,7 @@ const interpolatedMagnitudeHeightExpression: mapboxgl.ExpressionSpecification = 
   1500000,
 ];
 
-const basicPointStyle: mapboxgl.PaintSpecification = {
+const basicPointStyle: PaintSpecification = {
   'circle-color': magnitudeColorExpression,
   'circle-radius': 6,
   'circle-stroke-width': 2,
@@ -112,3 +114,10 @@ export const LAYERS: LayerConsts = {
     },
   },
 };
+
+//Layers with clustered source do not have the properties we need to filter on layer, so filtering happens at source level
+export const EXCLUDED_FILTER_LAYERS = [
+  LAYERS.CLUSTERED_EARTHQUAKES.id,
+  LAYERS.CLUSTERED_EARTHQUAKES_COUNT.id,
+  LAYERS.CLUSTERED_EARTHQUAKE_UNCLUSTERED_POINTS.id,
+];

--- a/src/consts/layers.ts
+++ b/src/consts/layers.ts
@@ -23,13 +23,11 @@ const interpolatedMagnitudeColorExpression: ExpressionSpecification = [
   2,
   '#0f0',
   4,
-  '#ff0',
+  '#ffff00',
   6,
-  '#f90',
-  8,
   '#f60',
-  10,
-  '#f00',
+  8,
+  '#F00',
 ];
 
 const interpolatedMagnitudeHeightExpression: ExpressionSpecification = [

--- a/src/consts/sourceData.types.ts
+++ b/src/consts/sourceData.types.ts
@@ -1,4 +1,6 @@
+import type { FeatureCollection } from 'geojson';
+
 export interface SourceData {
   id: string;
-  data: string;
+  data: FeatureCollection;
 }

--- a/src/stores/earthquakeStateStore.ts
+++ b/src/stores/earthquakeStateStore.ts
@@ -1,5 +1,12 @@
-import { defineStore } from 'pinia';
-import { ref, computed } from 'vue';
+import { defineStore, storeToRefs } from 'pinia';
+import { ref, computed, watch } from 'vue';
+
+import { useMapStore } from '@/stores/mapStore';
+import { useSourceDataStore } from '@/stores/sourceDataStore';
+
+import { LAYERS, EXCLUDED_FILTER_LAYERS } from '@/consts/layers';
+import { VISUALISATION } from '@/consts/visualisations';
+import type { Layer, Source, GeoJSONSource, ExpressionSpecification, Map, Layer } from 'mapbox-gl';
 
 export const useEarthquakeStateStore = defineStore('earthquakeState', () => {
   const selectedEarthquakeId = ref<string | null>();
@@ -14,11 +21,90 @@ export const useEarthquakeStateStore = defineStore('earthquakeState', () => {
     return filterDates.value[1]?.getTime();
   });
 
+  const updateLayerFilter = (map: Map, layerId: Layer['id']) => {
+    //Some layers already have filters in the consts
+    const existingFilters = LAYERS[layerId].filter || (null as ExpressionSpecification | null);
+    const filters: ExpressionSpecification[] = [];
+
+    //Search filter
+    if (filterSearchTerm.value) {
+      filters.push([
+        'all',
+        ['has', 'place'], // Ensure 'place' exists
+        [
+          'in',
+          filterSearchTerm.value.toLowerCase(), // Search term in lowercase
+          ['downcase', ['get', 'place']], // Convert 'place' to lowercase
+        ],
+      ]);
+    }
+
+    //Date range filter
+    if (filterDates.value?.length === 2) {
+      const startDate = new Date(filterDateFromTimestamp.value);
+      //To be consistent with the list filtering, the date timestamp should start at 00:00:00
+      startDate.setHours(0, 0, 0, 0);
+
+      const endDate = new Date(filterDateToTimestamp.value);
+      //To be consistent with the list filtering, the date timestamp should end at 23:59:59
+      endDate.setHours(23, 59, 59, 999);
+
+      filters.push([
+        'all',
+        ['>=', ['get', 'time'], startDate.getTime()],
+        ['<=', ['get', 'time'], endDate.getTime()],
+      ]);
+    }
+
+    let combinedFilter: ExpressionSpecification | null = null;
+
+    if (existingFilters) {
+      if (filters.length) {
+        //Combine the existing filters with the new ones
+        combinedFilter = ['all', existingFilters, ...filters] as ExpressionSpecification;
+      } else {
+        //If there are no new filters, just use the existing ones
+        combinedFilter = existingFilters as ExpressionSpecification;
+      }
+    } else {
+      //If there are no existing filters, just use the new ones
+      combinedFilter = ['all', ...filters] as ExpressionSpecification;
+    }
+
+    map.setFilter(layerId, combinedFilter);
+  };
+
+  //When filters change, apply them to the layers of the current visualisation
+  watch([filterSearchTerm, filterDates], () => {
+    const mapStore = useMapStore();
+    const { selectedVisualisationId } = storeToRefs(mapStore);
+    const sourceDataStore = useSourceDataStore();
+
+    const map = mapStore.map;
+
+    if (!map || !selectedVisualisationId.value) return;
+
+    const filteredData = sourceDataStore.getFilteredSourceData('earthquakes');
+
+    //Filter the data at source level for earthquakes clustered, because clusters do not have the properties we need to filter by
+    const source = map.getSource('earthquakes-clustered') as GeoJSONSource;
+    source.setData(filteredData);
+
+    const layerIds = VISUALISATION[selectedVisualisationId.value].layers;
+
+    layerIds.forEach((layerId) => {
+      if (EXCLUDED_FILTER_LAYERS.includes(layerId)) return;
+      // @ts-ignore
+      updateLayerFilter(map, layerId);
+    });
+  });
+
   return {
     selectedEarthquakeId,
     filterSearchTerm,
     filterDates,
     filterDateFromTimestamp,
     filterDateToTimestamp,
+    updateLayerFilter,
   };
 });

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -1,11 +1,11 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import mapboxgl, { LngLat } from 'mapbox-gl';
-import type { Map as MapboxMap, StyleSpecification } from 'mapbox-gl';
+import type { Map, StyleSpecification } from 'mapbox-gl';
 import { VISUALISATION } from '@/consts/visualisations';
 
 export const useMapStore = defineStore('map', () => {
-  const map = ref<MapboxMap | null>(null);
+  const map = ref<Map | null>(null);
   const localStyle = ref<StyleSpecification | undefined>(undefined);
   const selectedVisualisationId = ref<string>(VISUALISATION.NONE.id);
 

--- a/src/stores/sourceDataStore.ts
+++ b/src/stores/sourceDataStore.ts
@@ -1,8 +1,12 @@
-import { defineStore } from 'pinia';
 import { ref } from 'vue';
+import { defineStore } from 'pinia';
+
+import type { FeatureCollection } from 'geojson';
 import type { SourceData } from '@/consts/sourceData.types';
 
-//This store will hold source data that can be added to a Mapbox source
+import { useEarthquakeStateStore } from '@/stores/earthquakeStateStore';
+
+//This store will hold source data that can be added to the map. The ID in here does not need to match the ID of the mapbox source.
 export const useSourceDataStore = defineStore('sources', () => {
   const sourceData = ref<SourceData[]>([]);
 
@@ -20,5 +24,55 @@ export const useSourceDataStore = defineStore('sources', () => {
     return sourceData.value.find((s) => s.id === sourceDataId);
   };
 
-  return { sourceData, addSourceData, deleteSourceData, getSourceData };
+  //Filtered geojson source
+  const getFilteredSourceData = (sourceDataId: SourceData['id']): FeatureCollection => {
+    const earthquakeStateStore = useEarthquakeStateStore();
+
+    const geojson = sourceData.value.find((s) => s.id === sourceDataId)?.data as
+      | { features?: any[] }
+      | undefined;
+
+    const features = geojson?.features || [];
+
+    // Apply the filters based on the search term and date range
+    const filteredFeatures = features.filter((feature: any) => {
+      // Apply search filter if search term is provided
+      if (
+        earthquakeStateStore.filterSearchTerm &&
+        earthquakeStateStore.filterSearchTerm.trim() !== ''
+      ) {
+        const searchTerm = earthquakeStateStore.filterSearchTerm.toLowerCase();
+        const place = feature.properties?.place?.toLowerCase() || '';
+
+        if (!place.includes(searchTerm)) {
+          return false; // Filter out if the place doesn't include the search term
+        }
+      }
+
+      // Apply date filtering
+      if (earthquakeStateStore.filterDates?.length === 2) {
+        const earthquakeDate = new Date(feature.properties?.time);
+
+        const startDate = new Date(earthquakeStateStore.filterDateFromTimestamp);
+        const endDate = new Date(earthquakeStateStore.filterDateToTimestamp);
+
+        startDate.setHours(0, 0, 0, 0);
+        endDate.setHours(23, 59, 59, 999);
+
+        if (earthquakeDate < startDate || earthquakeDate > endDate) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+
+    return {
+      ...geojson,
+      type: 'FeatureCollection',
+      features: filteredFeatures,
+    };
+  };
+
+  return { sourceData, addSourceData, deleteSourceData, getSourceData, getFilteredSourceData };
 });


### PR DESCRIPTION
- Adds a new constant for layers that should not be filtered at a layer level, and instead should be filtred at a source level (clusters)
- Stronger type definitions (no more `mapboxgl.Map` etc)
- Perform feature filtering for the feature list (and when we want to set the data on the source) in the store instead
- Apply layer-level filters when filters change or visualisation changes

![image](https://github.com/user-attachments/assets/e69b770d-8eb8-4255-bcf6-2d4235695198)
